### PR TITLE
Session forms clear errors when moving from one page to another

### DIFF
--- a/app/assets/stylesheets/loginpage.scss
+++ b/app/assets/stylesheets/loginpage.scss
@@ -4,7 +4,7 @@
 }
 
 .login-form-location{
-    height: calc(100vh - 61px);
+    height: calc(100vh - 71px);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/frontend/actions/session_actions.js
+++ b/frontend/actions/session_actions.js
@@ -3,6 +3,7 @@ import * as APIUtil from '../util/session_api_util';
 export const RECEIVE_CURRENT_USER = 'RECEIVE_CURRENT_USER';
 export const LOGOUT_CURRENT_USER = 'LOGOUT_CURRENT_USER';
 export const RECEIVE_SESSION_ERRORS = 'RECEIVE_SESSION_ERRORS';
+export const CLEAR_SESSION_ERRORS = 'CLEAR_SESSION_ERRORS';
 
 //action creators
 
@@ -21,6 +22,10 @@ const receiveErrors = errors => ({
     errors
 });
 
+
+export const clearErrors = () => ({
+    type: CLEAR_SESSION_ERRORS
+});
 
 //thunk action creators
 

--- a/frontend/components/session_form/login_form_container.jsx
+++ b/frontend/components/session_form/login_form_container.jsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { login } from '../../actions/session_actions';
+import { login, clearErrors } from '../../actions/session_actions';
 import SessionForm from './session_form';
 
 const mapStateToProps = ({ errors }) => {
@@ -13,7 +13,8 @@ const mapStateToProps = ({ errors }) => {
 
 const mapDispatchToProps = dispatch => {
     return {
-        processForm: (user) => dispatch(login(user))
+        processForm: (user) => dispatch(login(user)),
+        clearErrors: () => dispatch(clearErrors())
     };
 };
 

--- a/frontend/components/session_form/session_form.jsx
+++ b/frontend/components/session_form/session_form.jsx
@@ -13,6 +13,10 @@ class SessionForm extends React.Component {
         this.handleDemoUser = this.handleDemoUser.bind(this);
     }
 
+    componentDidMount(){
+        this.props.clearErrors();
+    }
+
     update(field){
         return e => this.setState({
             [field]: e.currentTarget.value
@@ -35,13 +39,18 @@ class SessionForm extends React.Component {
     }
 
     renderErrors(){
-        return (
-            <ul className="errors-list">
-                {this.props.errors.map((error, i) => {
-                    return (<li key={`error-${i}`}>{error}</li>);
-                })}
-            </ul>
-        );
+        let errors = null;
+        if (this.props.errors) {
+            errors = (
+                <ul className="errors-list">
+                    {this.props.errors.map((error, i) => {
+                        return (<li key={`error-${i}`}>{error}</li>);
+                    })}
+                </ul>
+            );
+        }
+
+        return errors;
     }
 
     additionalInputs(){
@@ -64,7 +73,6 @@ class SessionForm extends React.Component {
     render() {
         return (
             <div>
-                
                 <div className="errors-form">{this.renderErrors()}</div>
                 <form onSubmit={this.handleSubmit} className="session-form">                
                     {this.additionalInputs()}

--- a/frontend/components/session_form/signup_form_container.jsx
+++ b/frontend/components/session_form/signup_form_container.jsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { login, signup } from '../../actions/session_actions';
+import { login, signup, clearErrors } from '../../actions/session_actions';
 import SessionForm from './session_form';
 
 const mapStateToProps = ({ errors }) => {
@@ -14,7 +14,8 @@ const mapStateToProps = ({ errors }) => {
 const mapDispatchToProps = dispatch => {
     return {
         processForm: (user) => dispatch(signup(user)),
-        demoLogin: (user) => dispatch(login(user))
+        demoLogin: (user) => dispatch(login(user)),
+        clearErrors: () => dispatch(clearErrors())
     };
 };
 

--- a/frontend/reducers/session_errors_reducer.js
+++ b/frontend/reducers/session_errors_reducer.js
@@ -1,6 +1,7 @@
 import {
     RECEIVE_SESSION_ERRORS,
-    RECEIVE_CURRENT_USER
+    RECEIVE_CURRENT_USER,
+    CLEAR_SESSION_ERRORS
 } from '../actions/session_actions';
 
 const sessionErrorsReducer = (state = [], action) => {
@@ -9,6 +10,8 @@ const sessionErrorsReducer = (state = [], action) => {
         case RECEIVE_SESSION_ERRORS:
             return action.errors;
         case RECEIVE_CURRENT_USER:
+            return [];
+        case CLEAR_SESSION_ERRORS:
             return [];
         default:
             return state;


### PR DESCRIPTION
Login/Sign up pages Errors

Issue: When a user hits submit on the login or sign up pages, error messages are displayed. If the user clicks on another page (going from login page to signup page or vice versa), the errors from the other form are still displayed. They were not being cleared.

Solution: I created a new action called clearErrors that updates the state to be an empty array. Then using ComponentDidMount, when the component renders for the first time, the errors will be cleared.