### PR TITLE
Delete channel form

### DIFF
--- a/app/controllers/api/channels_controller.rb
+++ b/app/controllers/api/channels_controller.rb
@@ -40,6 +40,12 @@ class Api::ChannelsController < ApplicationController
         end
     end
 
+    def destroy
+        @channel = Channel.find(params[:id])
+        @channel_membership = @channel.channel_memberships.where({channel_id: @channel.id}).delete_all
+        @channel.destroy
+    end
+
 
     def add_member
          @user = User.find(params[:user_id])

--- a/frontend/actions/channel_actions.js
+++ b/frontend/actions/channel_actions.js
@@ -24,6 +24,11 @@ const receiveErrors = errors => ({
     errors
 });
 
+const removeChannel = channelId => ({
+    type: REMOVE_CHANNEL,
+    channelId: channelId
+});
+
 
 const addMember = channelMembership => {
     const { channel, user } = channelMembership;
@@ -63,6 +68,10 @@ export const createChannel = channel => dispatch => {
 export const updateChannel = channel => dispatch => {
     return ChannelApiUtil.updateChannel(channel).then(channel => dispatch(receiveChannel(channel)),
     err => dispatch(receiveErrors(err.responseJSON)));
+}
+
+export const deleteChannel = channelId => dispatch => {
+    return ChannelApiUtil.deleteChannel(channelId).then(() => dispatch(removeChannel(channelId)));
 }
 
 

--- a/frontend/components/channel_form/remove_channel_form.jsx
+++ b/frontend/components/channel_form/remove_channel_form.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+class RemoveChannelForm extends React.Component {
+    constructor(props){
+        super(props)
+
+        this.handleSubmit = this.handleSubmit.bind(this);
+    }
+
+    handleSubmit(e) {
+        e.preventDefault();
+        this.props.processForm(this.props.channelId);
+        this.props.closeModal();
+    }
+
+    render(){
+        return (
+            <div className="remove-members-form-container">
+                <h2>Remove Channel</h2>
+                <p>Are you sure you want to delete the channel? This action will be permanent.</p>
+                <form onSubmit={this.handleSubmit} className="remove_members_form">
+                    <input className="remove-members-submit" type="submit" value="Yes" />
+                    <button onClick={this.props.closeModal} className="remove-members-cancel">No</button>
+                </form>
+            </div>
+        );
+    }
+}
+
+export default RemoveChannelForm;

--- a/frontend/components/channel_form/remove_channel_form_container.jsx
+++ b/frontend/components/channel_form/remove_channel_form_container.jsx
@@ -1,0 +1,21 @@
+import {connect} from 'react-redux';
+import { deleteChannel } from '../../actions/channel_actions';
+import { closeModal } from '../../actions/modal_actions';
+import RemoveChannelForm from './remove_channel_form';
+// import { withRouter } from 'react-router-dom';
+
+const mapStateToProps = (state, ownProps) => {
+    return {
+        errors: Object.values(state.errors.session),
+        channelId: state.ui.currentChannelId
+    }
+}
+
+const mapDispatchToProps = dispatch => {
+    return {
+        processForm: (channelId) => dispatch(deleteChannel(channelId)),
+        closeModal: () => dispatch(closeModal())
+    };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(RemoveChannelForm);

--- a/frontend/components/main/internal_navbar.jsx
+++ b/frontend/components/main/internal_navbar.jsx
@@ -33,7 +33,7 @@ class InternalNavbar extends React.Component {
                     {this.props.inviteMembersForm(channel.id)}
                     {this.props.removeMembersForm(channel.id)}
                     {this.props.updateChannelForm(channel.id)}
-                    {/* <button>Delete Channel</button> */}
+                    {this.props.removeChannelForm(channel.id)}
                 </ul>
             )
         } else {

--- a/frontend/components/main/internal_navbar_container.jsx
+++ b/frontend/components/main/internal_navbar_container.jsx
@@ -53,6 +53,11 @@ const mapDispatchToProps = dispatch => ({
         return (<li onClick={() => {
             dispatch(openModal('Update Channel', channelId))
         }}>Update channel</li>)
+    },
+    removeChannelForm: (channelId) => {
+        return (<li onClick={() => {
+            dispatch(openModal('Remove Channel', channelId))
+        }}>Remove Channel</li>)
     }
 });
 

--- a/frontend/components/modal/modal.jsx
+++ b/frontend/components/modal/modal.jsx
@@ -5,6 +5,7 @@ import CreateChannelFormContainer from '../channel_form/create_channel_form_cont
 import UpdateChannelFormContainer from '../channel_form/update_channel_modal';
 import InviteMembersFormContainer from '../channel_form/invite_members_form_container';
 import RemoveMembersFormContainer from '../channel_form/remove_members_form_container';
+import RemoveChannelFormContainer from '../channel_form/remove_channel_form_container';
 import { withRouter } from 'react-router-dom';
 
 function Modal({modal, closeModal}){
@@ -25,6 +26,9 @@ function Modal({modal, closeModal}){
             break;
         case 'Remove Members':
             component = <RemoveMembersFormContainer />
+            break;
+        case 'Remove Channel':
+            component = <RemoveChannelFormContainer />
             break;
         default:
             return null;

--- a/frontend/entry.jsx
+++ b/frontend/entry.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from "react-dom";
 import Root from "./components/root";
 import { signup, login, logout } from './actions/session_actions';
-import { createChannel, fetchChannel, updateChannel, fetchChannels, createChannelMembership, deleteChannelMembership } from './actions/channel_actions';
+import { createChannel, fetchChannel, updateChannel, deleteChannel, fetchChannels, createChannelMembership, deleteChannelMembership } from './actions/channel_actions';
 import configureStore from './store/store';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -28,6 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
     window.createChannel = createChannel;
     window.fetchChannel = fetchChannel;
     window.updateChannel = updateChannel;
+    window.deleteChannel = deleteChannel;
 
     window.getState = store.getState;
     window.dispatch = store.dispatch;

--- a/frontend/reducers/channels_reducer.js
+++ b/frontend/reducers/channels_reducer.js
@@ -1,4 +1,4 @@
-import { RECEIVE_CHANNEL, RECEIVE_CHANNELS, REMOVE_CHANNELMEMBERSHIP, RECEIVE_CHANNELMEMBERSHIP } from '../actions/channel_actions';
+import { RECEIVE_CHANNEL, RECEIVE_CHANNELS, REMOVE_CHANNEL, REMOVE_CHANNELMEMBERSHIP, RECEIVE_CHANNELMEMBERSHIP } from '../actions/channel_actions';
 
 const channelsReducer = (state = {}, action) => {
     Object.freeze(state);
@@ -7,6 +7,10 @@ const channelsReducer = (state = {}, action) => {
             return action.channels;
         case RECEIVE_CHANNEL:
             return Object.assign({}, state, { [action.channel.id]: action.channel });
+        case REMOVE_CHANNEL:
+            let newState = Object.assign({}, state);
+            delete newState[action.channelId];
+            return newState;
         case RECEIVE_CHANNELMEMBERSHIP:
             return Object.assign({}, state, { [action.channel.id]: action.channel});
         case REMOVE_CHANNELMEMBERSHIP:

--- a/frontend/util/channel_api_util.js
+++ b/frontend/util/channel_api_util.js
@@ -28,6 +28,13 @@ export const updateChannel = channel => (
     })
 );
 
+export const deleteChannel = channelId => (
+    $.ajax({
+        url: `/api/channels/${channelId}`,
+        method: 'DELETE'
+    })
+);
+
 export const addMemberToChannel = (channelId, memberId) => (
     $.ajax({ 
         url: `/api/channels/${channelId}/add_member`,


### PR DESCRIPTION
Before channels were able to be created but once they were created, there was no way to delete the channel. Now, I have added a remove channel form which opens up a modal allowing the user to completely delete a channel. It also removes the channel memberships of the deleted channel id.