### PR TITLE
Adds uninvited member to invite member form

### DIFF
--- a/frontend/components/channel_form/invite_members_form.jsx
+++ b/frontend/components/channel_form/invite_members_form.jsx
@@ -4,10 +4,10 @@ class InviteMembersForm extends React.Component {
     constructor(props){
         super(props);
         this.state = {
-            channel_id: '',
             member_id: ''
         }
-        this.handleSubmit = this.handleSubmit.bind(this);
+        // this.handleSubmit = this.handleSubmit.bind(this);
+        this.onButton = this.onButton.bind(this);
     }
 
     update(field) {
@@ -16,23 +16,25 @@ class InviteMembersForm extends React.Component {
         })
     }
 
-    handleSubmit(e) {
-        e.preventDefault();
-        const channel_id = this.state.channel_id;
-        this.props.processForm(this.state.channel_id, this.state.member_id);
+    onButton(val) {
+        this.props.processForm(this.props.channelId, val);
+        this.props.closeModal();
     }
 
     render(){
+        let { users, channels, channelId } = this.props;
+        let invitedUsers = channels[channelId].memberIds;
+        let notInvitedUsersLi = Object.values(users).map((user, i) => {
+            if(!invitedUsers.includes(user.id)){
+                return <li key={i}><button onClick={() => this.onButton(user.id)}>{user.name}</button></li>
+            }
+        });
         return (
             <div>
                 <button onClick={this.props.closeModal}>X</button>
-                <form onSubmit={this.handleSubmit} className="session-form">
-                    <label>Channel Id</label>
-                    <input placeholder="channel id" type="text" value={this.state.channel_id} onChange={this.update('channel_id')} />
-                    <label>Member Id</label>
-                    <input placeholder="member id" type="text" value={this.state.member_id} onChange={this.update('member_id')} />
-                    <input className="session-form-submit" type="submit" value="Submit" />
-                </form>
+                <ul>
+                    {notInvitedUsersLi}
+                </ul>
             </div>
         )
     }

--- a/frontend/components/channel_form/invite_members_form_container.jsx
+++ b/frontend/components/channel_form/invite_members_form_container.jsx
@@ -4,9 +4,12 @@ import { createChannelMembership } from '../../actions/channel_actions';
 import InviteMembersForm from './invite_members_form';
 
 
-const mapStateToProps = ({errors}) => {
+const mapStateToProps = (state) => {
     return {
-        errors: Object.values(errors.session)
+        errors: Object.values(state.errors.session),
+        channelId: state.ui.currentChannelId,
+        channels: state.entities.channels,
+        users: state.entities.users
     }
 };
 

--- a/frontend/components/main/member_list.jsx
+++ b/frontend/components/main/member_list.jsx
@@ -12,6 +12,7 @@ class MemberList extends React.Component {
         })
         return (
             <div>
+                <button onClick={this.props.closeModal}>X</button>
                 <ul>
                     {memberNamesLi}
                 </ul>


### PR DESCRIPTION
The invite member form asked for id input from users to actually invite people. Now, the form is refactored to display members who are not already invited in the channel.